### PR TITLE
fix(intl-polyfill): ensure Intl polyfill loaded before plugin

### DIFF
--- a/src/df.js
+++ b/src/df.js
@@ -7,8 +7,11 @@ export class DfValueConverter {
   }
 
   toView(value, formatOptions, locale, dateFormat) {
-    var df = dateFormat || this.service.df(formatOptions, locale || this.service.getLocale());
-
-    return df.format(value);
+    let ret = value;
+    if (ret) {
+      var df = dateFormat || this.service.df(formatOptions, locale || this.service.getLocale());
+      ret =  df.format(value);
+    }
+    return ret;
   }
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,13 +7,6 @@ export class I18N {
     this.i18next = i18n;
     this.ea = ea;
     this.Intl = window.Intl;
-
-    // check whether Intl is available, otherwise load the polyfill
-    if(window.Intl === undefined) {
-      System.import('Intl').then( (poly) => {
-        window.Intl = poly;
-      });
-    }
   }
 
   setup(options) {

--- a/src/index.js
+++ b/src/index.js
@@ -32,12 +32,12 @@ export function configure(aurelia, cb){
     ret = new Promise((accept,reject) => {
         System['import']('Intl').then((poly) => {
           window.Intl = poly;
-          onIntlLoaded(aurelia,cb).then(accept,reject);
+          onIntlLoaded().then(accept,reject);
         });
     });
   }
   else {
-    ret = onIntlLoaded(aurelia, cb);
+    ret = onIntlLoaded();
   }
 
   return ret;

--- a/src/index.js
+++ b/src/index.js
@@ -20,5 +20,18 @@ export function configure(aurelia, cb){
   var instance = new I18N(aurelia.container.get(EventAggregator));
   aurelia.container.registerInstance(I18N, instance);
 
-  return cb(instance);
+  var ret = cb(instance),
+    promises = [];
+  // check whether Intl is available, otherwise load the polyfill
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
+  if (window.Intl === undefined) {
+    promises.push(System['import']('Intl').then((poly) => {
+      window.Intl = poly;
+    }));
+  }
+  if(ret && (ret instanceof Promise)) {
+    promises.push(ret);
+  }
+  return promises.length > 0 ? Promise.all(promises) : ret;
+
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export {RtValueConverter} from './rt';
 export {TValueConverter} from './t';
 
 export function configure(aurelia, cb){
-  if(cb === undefined || typeof cb !== 'function') {
+  if(typeof cb !== 'function') {
     throw 'You need to provide a callback method to properly configure the library';
   }
 
@@ -17,21 +17,28 @@ export function configure(aurelia, cb){
   aurelia.globalizeResources('./nf');
   aurelia.globalizeResources('./df');
   aurelia.globalizeResources('./rt');
-  var instance = new I18N(aurelia.container.get(EventAggregator));
-  aurelia.container.registerInstance(I18N, instance);
 
-  var ret = cb(instance),
-    promises = [];
+  let ret = null,
+    onIntlLoaded = () => {
+      var instance = new I18N(aurelia.container.get(EventAggregator));
+      aurelia.container.registerInstance(I18N, instance);
+      var ret = cb(instance);
+      return ret && ret instanceof Promise ? ret : Promise.resolve();
+    };
+
   // check whether Intl is available, otherwise load the polyfill
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
-  if (window.Intl === undefined) {
-    promises.push(System['import']('Intl').then((poly) => {
-      window.Intl = poly;
-    }));
+  if (!window.Intl) {
+    ret = new Promise((accept,reject) => {
+        System['import']('Intl').then((poly) => {
+          window.Intl = poly;
+          onIntlLoaded(aurelia,cb).then(accept,reject);
+        });
+    });
   }
-  if(ret && (ret instanceof Promise)) {
-    promises.push(ret);
+  else {
+    ret = onIntlLoaded(aurelia, cb);
   }
-  return promises.length > 0 ? Promise.all(promises) : ret;
 
+  return ret;
 }

--- a/src/nf.js
+++ b/src/nf.js
@@ -7,8 +7,11 @@ export class NfValueConverter {
   }
 
   toView(value, formatOptions, locale, numberFormat) {
-    var nf = numberFormat || this.service.nf(formatOptions, locale || this.service.getLocale());
-
-    return nf.format(value);
+    let ret = value;
+    if(ret) {
+      var nf = numberFormat || this.service.nf(formatOptions, locale || this.service.getLocale());
+      ret = nf.format(value);
+    }
+    return ret;
   }
 }


### PR DESCRIPTION
- Loads Intl polyfill in plugin's configure method vs. constructor.
- Returns a Promise from configure when polyfill is loaded.
- I18N instantiation and callback execution refactored to onIntlLoaded function
- onIntlLoaded called iff Intl is available.
- Callback function may also return a Promise.  When a Promise is returned, the outer Promise ( returned from configure ) will not resolve until the inner promise is resolved.
